### PR TITLE
feat: Add human-readable byte formatting for download sizes and speeds

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, AppMode};
+use crate::utils::{format_bytes, format_speed};
 use ratatui::{
     Terminal,
     layout::{Constraint, Direction, Layout, Alignment},
@@ -105,20 +106,30 @@ pub fn render_ui<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, app: 
                         .iter()
                         .enumerate()
                         .map(|(i, t)| {
-                            let progress = if let (Ok(completed), Ok(total)) = (t.completed_length.parse::<u64>(), t.total_length.parse::<u64>()) {
-                                if total > 0 {
+                            let (formatted_completed, formatted_total, progress) = if let (Ok(completed), Ok(total)) = (t.completed_length.parse::<u64>(), t.total_length.parse::<u64>()) {
+                                let formatted_completed = format_bytes(completed);
+                                let formatted_total = format_bytes(total);
+                                let progress = if total > 0 {
                                     format!(" ({:.1}%)", (completed as f64 / total as f64) * 100.0)
                                 } else {
                                     String::new()
-                                }
+                                };
+                                (formatted_completed, formatted_total, progress)
                             } else {
-                                String::new()
+                                (t.completed_length.clone(), t.total_length.clone(), String::new())
                             };
 
                             let title = format!(
-                                "📁 {} - {}/{} bytes{} @ {} B/s",
-                                t.status, t.completed_length, t.total_length, progress, t.download_speed
+                                "📁 {} - {}/{} {}",
+                                t.status, formatted_completed, formatted_total, progress
                             );
+
+                            // Add speed info if available
+                            let title = if t.download_speed != "0" && !t.download_speed.is_empty() {
+                                format!("{} @ {}", title, format_speed(&t.download_speed))
+                            } else {
+                                title
+                            };
                             let style = if i == app.selected_index && app.mode == AppMode::Normal {
                                 Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
                             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,3 +39,39 @@ pub fn ensure_download_dir_exists(path: &PathBuf) -> std::io::Result<()> {
     }
     Ok(())
 }
+
+/// Format bytes into human-readable format (B, KB, MB, GB, TB)
+pub fn format_bytes(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit_index = 0;
+
+    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit_index += 1;
+    }
+
+    if unit_index == 0 {
+        format!("{}", bytes)
+    } else {
+        format!("{:.1} {}", size, UNITS[unit_index])
+    }
+}
+
+/// Format download speed in human-readable format
+pub fn format_speed(speed: &str) -> String {
+    if let Ok(bytes_per_sec) = speed.parse::<u64>() {
+        if bytes_per_sec == 0 {
+            "0B/s".to_string()
+        } else {
+            let formatted = format_bytes(bytes_per_sec);
+            if formatted.contains(' ') {
+                format!("{}/s", formatted)
+            } else {
+                format!("{}B/s", formatted)
+            }
+        }
+    } else {
+        format!("{}B/s", speed)
+    }
+}

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use tempfile::tempdir;
-use tui_torrent::utils::ensure_download_dir_exists;
+use tui_torrent::utils::{ensure_download_dir_exists, format_bytes, format_speed};
 
 #[test]
 fn ensure_download_dir_creates_path() {
@@ -9,4 +9,26 @@ fn ensure_download_dir_creates_path() {
     assert!(!nested.exists());
     ensure_download_dir_exists(&PathBuf::from(&nested)).expect("create");
     assert!(nested.exists());
+}
+
+#[test]
+fn test_format_bytes() {
+    assert_eq!(format_bytes(0), "0");
+    assert_eq!(format_bytes(512), "512");
+    assert_eq!(format_bytes(1024), "1.0 KB");
+    assert_eq!(format_bytes(1536), "1.5 KB");
+    assert_eq!(format_bytes(1024 * 1024), "1.0 MB");
+    assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GB");
+    assert_eq!(format_bytes(1024 * 1024 * 1024 * 1024), "1.0 TB");
+    assert_eq!(format_bytes(2147483648), "2.0 GB"); // 2GB
+}
+
+#[test]
+fn test_format_speed() {
+    assert_eq!(format_speed("0"), "0B/s");
+    assert_eq!(format_speed("512"), "512B/s");
+    assert_eq!(format_speed("1024"), "1.0 KB/s");
+    assert_eq!(format_speed("1048576"), "1.0 MB/s");
+    assert_eq!(format_speed("1073741824"), "1.0 GB/s");
+    assert_eq!(format_speed("invalid"), "invalidB/s");
 }


### PR DESCRIPTION
hey, thx for making this handy tool!

I'm not sure if you are looking for contributors but I was getting a bit stressed seeing the massive byte numbers so i cooked up a formater util. 
(and a filename display, separate PR possibly)

Later I realised there is also a crate ([bytesize](https://crates.io/crates/bytesize)) for this but i think the handrolled limited functionality here is fine.

Possibly this is of some use to you?

If you are open to more contributions, I'm interested to hear your plans/roadmap, if any, and see where I can help.

Regardless, thx again
saludos



